### PR TITLE
fix: types are now nullable unions

### DIFF
--- a/tests/snapshots/cli__nested_object_and_array.snap
+++ b/tests/snapshots/cli__nested_object_and_array.snap
@@ -17,36 +17,42 @@ expression: json
     },
     {
       "name": "address",
-      "type": {
-        "type": "record",
-        "name": "address",
-        "namespace": "schema",
-        "fields": [
-          {
-            "name": "street",
-            "type": "string"
-          },
-          {
-            "name": "city",
-            "type": "string"
-          },
-          {
-            "name": "state",
-            "type": "string"
-          },
-          {
-            "name": "postalCode",
-            "type": "string"
-          }
-        ]
-      }
+      "type": [
+        "null",
+        {
+          "type": "record",
+          "name": "address",
+          "namespace": "schema",
+          "fields": [
+            {
+              "name": "street",
+              "type": "string"
+            },
+            {
+              "name": "city",
+              "type": "string"
+            },
+            {
+              "name": "state",
+              "type": "string"
+            },
+            {
+              "name": "postalCode",
+              "type": "string"
+            }
+          ]
+        }
+      ]
     },
     {
       "name": "hobbies",
-      "type": {
-        "type": "array",
-        "items": "string"
-      }
+      "type": [
+        "null",
+        {
+          "type": "array",
+          "items": "string"
+        }
+      ]
     }
   ]
 }


### PR DESCRIPTION
**Before:** there are no null union types on non-required properties, the diff shows them being "lost" (in red on the left)

<img width="1795" height="1900" alt="Screenshot from 2025-08-31 22-50-00" src="https://github.com/user-attachments/assets/1b214870-e7ba-408f-9987-563481542e6f" />

**After:** the nulls are correct!

<img width="2118" height="1407" alt="Screenshot from 2025-08-31 22-49-16" src="https://github.com/user-attachments/assets/9e1b365f-a102-4fe3-93fa-2dca24f3c265" />