### PR TITLE
schema namespace fix

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -77,12 +77,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "anyhow"
-version = "1.0.99"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b0674a1ddeecb70197781e945de4b3b8ffb61fa939a5597bcf48503737663100"
-
-[[package]]
 name = "assert_cmd"
 version = "2.0.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -271,12 +265,6 @@ name = "doc-comment"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fea41bba32d969b513997752735605054bc0dfa92b4c56bf1189f2e174be7a10"
-
-[[package]]
-name = "either"
-version = "1.15.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
 
 [[package]]
 name = "encode_unicode"
@@ -771,15 +759,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7943c866cc5cd64cbc25b2e01621d07fa8eb2a1a23160ee81ce38704e97b8ecf"
 
 [[package]]
-name = "itertools"
-version = "0.14.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2b192c782037fadd9cfa75548310488aabdbf3d2da73885b31bd0abd03351285"
-dependencies = [
- "either",
-]
-
-[[package]]
 name = "itoa"
 version = "1.0.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -796,24 +775,12 @@ dependencies = [
 ]
 
 [[package]]
-name = "json-ptr"
-version = "0.3.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3618f91b6089312911655ae036dde80a336463615768bcbe7a02c971c822815b"
-dependencies = [
- "serde_json",
-]
-
-[[package]]
 name = "jsonschema2avro"
 version = "0.1.0"
 dependencies = [
- "anyhow",
  "assert_cmd",
  "clap",
  "insta",
- "itertools",
- "json-ptr",
  "predicates",
  "regex",
  "reqwest",

--- a/src/converter/conversion.rs
+++ b/src/converter/conversion.rs
@@ -270,10 +270,13 @@ pub fn json_schema_object_to_avro_record(
                 }
             }
 
-            let field = json!({
+            let mut field = json!({
                 "name": field_name,
                 "type": field_type
             });
+            if let Some(desc) = field_schema.get("description").and_then(|d| d.as_str()) {
+                field["doc"] = Value::String(desc.to_string());
+            }
             avro_record["fields"].as_array_mut().unwrap().push(field);
             dependencies.extend(deps);
         }

--- a/src/converter/conversion.rs
+++ b/src/converter/conversion.rs
@@ -334,6 +334,9 @@ pub fn json_schema_object_to_avro_record(
             if let Some(desc) = field_schema.get("description").and_then(|d| d.as_str()) {
                 field["doc"] = Value::String(desc.to_string());
             }
+            if let Some(c) = field_schema.get("const").cloned() {
+                field["const"] = c;
+            }
             avro_record["fields"].as_array_mut().unwrap().push(field);
             dependencies.extend(deps);
         }
@@ -523,7 +526,11 @@ pub fn json_type_to_avro_type(
                 .iter()
                 .filter_map(|v| v.as_str().map(avro_name))
                 .collect();
-            let enum_type = create_enum_type(&local_name, namespace, &symbols);
+            let mut enum_type = create_enum_type(&local_name, namespace, &symbols);
+            if let Some(desc) = obj.get("description").and_then(|d| d.as_str()) {
+                enum_type["doc"] = Value::String(desc.to_string());
+            }
+
             return merge_avro_schemas(
                 &[avro_type, enum_type],
                 avro_schema,

--- a/src/converter/definitions.rs
+++ b/src/converter/definitions.rs
@@ -61,7 +61,10 @@ pub fn process_definition(
     let mut avro_schema_items = match avro_schema_item_list {
         Value::Array(arr) => arr,
         item if item.is_object() => vec![item],
-        _ => return None,
+        _ => {
+            dbg!("process_definition: returning None");
+            return None;
+        }
     };
 
     if is_root && avro_schema_items.len() > 1 {
@@ -74,6 +77,11 @@ pub fn process_definition(
             Value::Array(avro_schema_items.clone()),
         );
         register_type(avro_schema, wrapper.clone());
+        dbg!((
+            "process_definition: root wrapper",
+            wrapper.get("namespace"),
+            wrapper.get("name")
+        ));
         return Some((
             wrapper
                 .get("namespace")
@@ -102,6 +110,7 @@ pub fn process_definition(
             .unwrap_or(namespace);
 
         if is_standalone_avro_type(&avro_item) && !is_empty_type(&avro_item) {
+            dbg!(("process_definition: standalone", ns, name));
             register_type(avro_schema, avro_item.clone());
             return Some((ns.to_string(), name.to_string()));
         }
@@ -112,6 +121,7 @@ pub fn process_definition(
             lift_dependencies_from_type(&mut item_copy, &mut deps);
 
             let wrapper = create_wrapper_record(schema_name, ns, name, &deps, item_copy);
+            dbg!(("process_definition: root wrapper", ns, name));
             register_type(avro_schema, wrapper.clone());
             return Some((
                 wrapper

--- a/src/converter/utils.rs
+++ b/src/converter/utils.rs
@@ -93,11 +93,10 @@ pub fn id_to_avro_namespace(id: &str) -> String {
     if let Ok(parsed_url) = Url::parse(id) {
         // Path → strip extension, replace `-` with `_`, split, reverse
         let path_no_ext = {
-            let path = parsed_url.path();
-            match Path::new(path).file_stem() {
-                Some(stem) => stem.to_string_lossy().replace('-', "_"),
-                None => path.trim_matches('/').replace('-', "_"),
-            }
+            let path = parsed_url.path().trim_matches('/');
+            // Take only the part before the first dot
+            let before_dot = path.split('.').next().unwrap_or("");
+            before_dot.replace('-', "_")
         };
         let path_segments: Vec<&str> = path_no_ext.split('/').filter(|s| !s.is_empty()).collect();
         let reversed_path_segments: Vec<&str> = path_segments.into_iter().rev().collect();

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -39,7 +39,13 @@ fn run_fixture(schema_path: &str, stem: &str) {
 #[case("array_of_objects")]
 #[case("object_with_optional")]
 #[case("object_with_defs")]
+#[case("object_with_const_field")]
+#[case("object_with_default_value")]
+#[case("object_with_explicit_nullable_type")]
+#[case("object_with_enum_array")]
 fn cli_fixtures(#[case] stem: &str) {
     let schema_path = format!("tests/fixtures/jsonschema/{stem}.json");
     run_fixture(&schema_path, stem);
 }
+//#[case("object_with_map_via_additional_props")]
+//#[case("object_with_oneof_anyof")]

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -38,8 +38,8 @@ fn run_fixture(schema_path: &str, stem: &str) {
 #[case("enum_string_property")]
 #[case("array_of_objects")]
 #[case("object_with_optional")]
+#[case("object_with_defs")]
 fn cli_fixtures(#[case] stem: &str) {
     let schema_path = format!("tests/fixtures/jsonschema/{stem}.json");
     run_fixture(&schema_path, stem);
 }
-// #[case("object_with_defs")]

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -7,8 +7,8 @@ use tempfile::tempdir;
 
 fn run_fixture(schema_path: &str, stem: &str) {
     let dir = tempdir().unwrap();
-    let input_path = dir.path().join("schema.json");
-    let output_path = dir.path().join("schema.avsc");
+    let input_path = dir.path().join(format!("{stem}.json"));
+    let output_path = dir.path().join(format!("{stem}.avsc"));
 
     // Load schema and copy into tmpdir
     let schema = fs::read_to_string(schema_path).unwrap();

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -34,7 +34,12 @@ fn run_fixture(schema_path: &str, stem: &str) {
 #[case("basic_string_schema")]
 #[case("basic_string_schema_with_title")]
 #[case("nested_object_and_array")]
+#[case("object_with_boolean_and_number")]
+#[case("enum_string_property")]
+#[case("array_of_objects")]
+#[case("object_with_optional")]
 fn cli_fixtures(#[case] stem: &str) {
     let schema_path = format!("tests/fixtures/jsonschema/{stem}.json");
     run_fixture(&schema_path, stem);
 }
+// #[case("object_with_defs")]

--- a/tests/fixtures/avro/array_of_objects.avsc
+++ b/tests/fixtures/avro/array_of_objects.avsc
@@ -1,0 +1,31 @@
+{
+    "type": "record",
+    "name": "document",
+    "namespace": "array_of_objects",
+    "fields": [
+        {
+            "name": "items",
+            "type": {
+                "type": "array",
+                "items": {
+                    "name": "items",
+                    "type": "record",
+                    "namespace": "array_of_objects.document_types",
+                    "fields": [
+                        {
+                            "name": "id",
+                            "type": "int"
+                        },
+                        {
+                            "name": "label",
+                            "type": [
+                                "null",
+                                "string"
+                            ]
+                        }
+                    ]
+                }
+            }
+        }
+    ]
+}

--- a/tests/fixtures/avro/enum_string_property.avsc
+++ b/tests/fixtures/avro/enum_string_property.avsc
@@ -10,8 +10,8 @@
                 "name": "color",
                 "namespace": "enum_string_property.document_types",
                 "symbols": [
-                    "blue",
                     "red",
+                    "blue",
                     "green"
                 ]
             },

--- a/tests/fixtures/avro/enum_string_property.avsc
+++ b/tests/fixtures/avro/enum_string_property.avsc
@@ -1,0 +1,21 @@
+{
+    "type": "record",
+    "name": "document",
+    "namespace": "enum_string_property",
+    "fields": [
+        {
+            "name": "color",
+            "type": {
+                "type": "enum",
+                "name": "color",
+                "namespace": "enum_string_property.document_types",
+                "symbols": [
+                    "blue",
+                    "red",
+                    "green"
+                ]
+            },
+            "doc": "One of a fixed set of colors"
+        }
+    ]
+}

--- a/tests/fixtures/avro/object_with_boolean_and_number.avsc
+++ b/tests/fixtures/avro/object_with_boolean_and_number.avsc
@@ -1,0 +1,20 @@
+{
+    "type": "record",
+    "name": "document",
+    "namespace": "object_with_boolean_and_number",
+    "fields": [
+        {
+            "name": "enabled",
+            "type": "boolean",
+            "doc": "Feature toggle"
+        },
+        {
+            "name": "count",
+            "type": [
+                "null",
+                "float"
+            ],
+            "doc": "A non-negative floating-point number"
+        }
+    ]
+}

--- a/tests/fixtures/avro/object_with_const_field.avsc
+++ b/tests/fixtures/avro/object_with_const_field.avsc
@@ -1,0 +1,21 @@
+{
+    "type": "record",
+    "name": "document",
+    "namespace": "object_with_const_field",
+    "fields": [
+        {
+            "name": "kind",
+            "type": {
+                "name": "kind",
+                "doc": "This field is always 'fixedValue'",
+                "type": "enum",
+                "namespace": "object_with_const_field",
+                "symbols": [
+                    "fixedValue"
+                ]
+            },
+            "const": "fixedValue",
+            "doc": "This field is always 'fixedValue'"
+        }
+    ]
+}

--- a/tests/fixtures/avro/object_with_default_value.avsc
+++ b/tests/fixtures/avro/object_with_default_value.avsc
@@ -1,0 +1,16 @@
+{
+    "type": "record",
+    "name": "document",
+    "namespace": "object_with_default_value",
+    "fields": [
+        {
+            "name": "level",
+            "type": [
+                "null",
+                "int"
+            ],
+            "default": 1,
+            "doc": "Defaults to 1 if not provided"
+        }
+    ]
+}

--- a/tests/fixtures/avro/object_with_defs.avsc
+++ b/tests/fixtures/avro/object_with_defs.avsc
@@ -1,0 +1,35 @@
+[
+    {
+        "type": "record",
+        "name": "address",
+        "namespace": "object_with_defs",
+        "fields": [
+            {
+                "name": "street",
+                "type": "string"
+            },
+            {
+                "name": "city",
+                "type": "string"
+            }
+        ]
+    },
+    {
+        "type": "record",
+        "name": "document",
+        "namespace": "object_with_defs",
+        "fields": [
+            {
+                "name": "shippingAddress",
+                "type": "object_with_defs.address"
+            },
+            {
+                "name": "billingAddress",
+                "type": [
+                    "null",
+                    "object_with_defs.address"
+                ]
+            }
+        ]
+    }
+]

--- a/tests/fixtures/avro/object_with_enum_array.avsc
+++ b/tests/fixtures/avro/object_with_enum_array.avsc
@@ -1,0 +1,23 @@
+{
+    "type": "record",
+    "name": "document",
+    "namespace": "object_with_enum_array",
+    "fields": [
+        {
+            "name": "statuses",
+            "type": {
+                "type": "array",
+                "items": {
+                    "type": "enum",
+                    "name": "statuses",
+                    "namespace": "object_with_enum_array.document_types",
+                    "symbols": [
+                        "DONE",
+                        "NEW",
+                        "PROCESSING"
+                    ]
+                }
+            }
+        }
+    ]
+}

--- a/tests/fixtures/avro/object_with_explicit_nullable_type.avsc
+++ b/tests/fixtures/avro/object_with_explicit_nullable_type.avsc
@@ -1,0 +1,14 @@
+{
+    "type": "record",
+    "name": "document",
+    "namespace": "object_with_explicit_nullable_type",
+    "fields": [
+        {
+            "name": "maybeName",
+            "type": [
+                "null",
+                "string"
+            ]
+        }
+    ]
+}

--- a/tests/fixtures/avro/object_with_map_via_additional_props.avsc
+++ b/tests/fixtures/avro/object_with_map_via_additional_props.avsc
@@ -1,0 +1,18 @@
+{
+    "type": "record",
+    "name": "document",
+    "namespace": "object_with_map_via_additional_props",
+    "fields": [
+        {
+            "name": "labels",
+            "type": [
+                "null",
+                {
+                    "name": "labels",
+                    "type": "map",
+                    "values": "string"
+                }
+            ]
+        }
+    ]
+}

--- a/tests/fixtures/avro/object_with_oneof_anyof.avsc
+++ b/tests/fixtures/avro/object_with_oneof_anyof.avsc
@@ -1,0 +1,14 @@
+{
+    "type": "record",
+    "name": "document",
+    "namespace": "object_with_oneof_anyof",
+    "fields": [
+        {
+            "name": "value",
+            "type": [
+                "string",
+                "int"
+            ]
+        }
+    ]
+}

--- a/tests/fixtures/avro/object_with_optional.avsc
+++ b/tests/fixtures/avro/object_with_optional.avsc
@@ -1,0 +1,18 @@
+{
+    "type": "record",
+    "name": "document",
+    "namespace": "object_with_optional",
+    "fields": [
+        {
+            "name": "id",
+            "type": "int"
+        },
+        {
+            "name": "nickname",
+            "type": [
+                "null",
+                "string"
+            ]
+        }
+    ]
+}

--- a/tests/fixtures/jsonschema/array_of_objects.json
+++ b/tests/fixtures/jsonschema/array_of_objects.json
@@ -1,0 +1,19 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "Array of Objects",
+  "type": "object",
+  "properties": {
+    "items": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "properties": {
+          "id": { "type": "integer" },
+          "label": { "type": "string" }
+        },
+        "required": ["id"]
+      }
+    }
+  },
+  "required": ["items"]
+}

--- a/tests/fixtures/jsonschema/enum_string_property.json
+++ b/tests/fixtures/jsonschema/enum_string_property.json
@@ -1,0 +1,13 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "Enum String Property",
+  "type": "object",
+  "properties": {
+    "color": {
+      "type": "string",
+      "enum": ["red", "green", "blue"],
+      "description": "One of a fixed set of colors"
+    }
+  },
+  "required": ["color"]
+}

--- a/tests/fixtures/jsonschema/object_with_boolean_and_number.json
+++ b/tests/fixtures/jsonschema/object_with_boolean_and_number.json
@@ -1,0 +1,17 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "Object with Boolean and Number",
+  "type": "object",
+  "properties": {
+    "enabled": {
+      "type": "boolean",
+      "description": "Feature toggle"
+    },
+    "count": {
+      "type": "number",
+      "minimum": 0,
+      "description": "A non-negative floating-point number"
+    }
+  },
+  "required": ["enabled"]
+}

--- a/tests/fixtures/jsonschema/object_with_const_field.json
+++ b/tests/fixtures/jsonschema/object_with_const_field.json
@@ -1,0 +1,12 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "Const Field",
+  "type": "object",
+  "properties": {
+    "kind": {
+      "const": "fixedValue",
+      "description": "This field is always 'fixedValue'"
+    }
+  },
+  "required": ["kind"]
+}

--- a/tests/fixtures/jsonschema/object_with_default_value.json
+++ b/tests/fixtures/jsonschema/object_with_default_value.json
@@ -1,0 +1,12 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "Default Value Field",
+  "type": "object",
+  "properties": {
+    "level": {
+      "type": "integer",
+      "default": 1,
+      "description": "Defaults to 1 if not provided"
+    }
+  }
+}

--- a/tests/fixtures/jsonschema/object_with_defs.json
+++ b/tests/fixtures/jsonschema/object_with_defs.json
@@ -1,0 +1,20 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "Object with Defs",
+  "type": "object",
+  "$defs": {
+    "address": {
+      "type": "object",
+      "properties": {
+        "street": { "type": "string" },
+        "city": { "type": "string" }
+      },
+      "required": ["street", "city"]
+    }
+  },
+  "properties": {
+    "shippingAddress": { "$ref": "#/$defs/address" },
+    "billingAddress": { "$ref": "#/$defs/address" }
+  },
+  "required": ["shippingAddress"]
+}

--- a/tests/fixtures/jsonschema/object_with_enum_array.json
+++ b/tests/fixtures/jsonschema/object_with_enum_array.json
@@ -1,0 +1,15 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "Array of Enums",
+  "type": "object",
+  "properties": {
+    "statuses": {
+      "type": "array",
+      "items": {
+        "type": "string",
+        "enum": ["NEW", "PROCESSING", "DONE"]
+      }
+    }
+  },
+  "required": ["statuses"]
+}

--- a/tests/fixtures/jsonschema/object_with_explicit_nullable_type.json
+++ b/tests/fixtures/jsonschema/object_with_explicit_nullable_type.json
@@ -1,0 +1,10 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "Nullable Field",
+  "type": "object",
+  "properties": {
+    "maybeName": {
+      "type": ["string", "null"]
+    }
+  }
+}

--- a/tests/fixtures/jsonschema/object_with_map_via_additional_props.json
+++ b/tests/fixtures/jsonschema/object_with_map_via_additional_props.json
@@ -1,0 +1,11 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "Map of Strings",
+  "type": "object",
+  "properties": {
+    "labels": {
+      "type": "object",
+      "additionalProperties": { "type": "string" }
+    }
+  }
+}

--- a/tests/fixtures/jsonschema/object_with_oneof_anyof.json
+++ b/tests/fixtures/jsonschema/object_with_oneof_anyof.json
@@ -1,0 +1,14 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "OneOf Example",
+  "type": "object",
+  "properties": {
+    "value": {
+      "oneOf": [
+        { "type": "string" },
+        { "type": "integer" }
+      ]
+    }
+  },
+  "required": ["value"]
+}

--- a/tests/fixtures/jsonschema/object_with_optional.json
+++ b/tests/fixtures/jsonschema/object_with_optional.json
@@ -1,0 +1,10 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "Object with Optional Fields",
+  "type": "object",
+  "properties": {
+    "id": { "type": "integer" },
+    "nickname": { "type": "string" }
+  },
+  "required": ["id"]
+}

--- a/tests/snapshots/cli__array_of_objects.snap
+++ b/tests/snapshots/cli__array_of_objects.snap
@@ -1,0 +1,35 @@
+---
+source: tests/cli.rs
+expression: json
+---
+{
+  "type": "record",
+  "name": "document",
+  "namespace": "array_of_objects",
+  "fields": [
+    {
+      "name": "items",
+      "type": {
+        "type": "array",
+        "items": {
+          "type": "record",
+          "name": "items",
+          "namespace": "array_of_objects.document_types",
+          "fields": [
+            {
+              "name": "id",
+              "type": "int"
+            },
+            {
+              "name": "label",
+              "type": [
+                "null",
+                "string"
+              ]
+            }
+          ]
+        }
+      }
+    }
+  ]
+}

--- a/tests/snapshots/cli__basic_string_schema.snap
+++ b/tests/snapshots/cli__basic_string_schema.snap
@@ -5,7 +5,7 @@ expression: json
 {
   "type": "record",
   "name": "document",
-  "namespace": "schema",
+  "namespace": "basic_string_schema",
   "fields": [
     {
       "name": "name",

--- a/tests/snapshots/cli__basic_string_schema_with_title.snap
+++ b/tests/snapshots/cli__basic_string_schema_with_title.snap
@@ -5,7 +5,7 @@ expression: json
 {
   "type": "record",
   "name": "document",
-  "namespace": "schema",
+  "namespace": "basic_string_schema_with_title",
   "fields": [
     {
       "name": "name",

--- a/tests/snapshots/cli__enum_string_property.snap
+++ b/tests/snapshots/cli__enum_string_property.snap
@@ -1,0 +1,25 @@
+---
+source: tests/cli.rs
+expression: json
+---
+{
+  "type": "record",
+  "name": "document",
+  "namespace": "enum_string_property",
+  "fields": [
+    {
+      "name": "color",
+      "type": {
+        "type": "enum",
+        "name": "color",
+        "namespace": "enum_string_property.document_types",
+        "symbols": [
+          "red",
+          "green",
+          "blue"
+        ]
+      },
+      "doc": "One of a fixed set of colors"
+    }
+  ]
+}

--- a/tests/snapshots/cli__nested_object_and_array.snap
+++ b/tests/snapshots/cli__nested_object_and_array.snap
@@ -5,7 +5,7 @@ expression: json
 {
   "type": "record",
   "name": "document",
-  "namespace": "schema",
+  "namespace": "com.example.complex_object.schema",
   "fields": [
     {
       "name": "name",
@@ -22,7 +22,7 @@ expression: json
         {
           "type": "record",
           "name": "address",
-          "namespace": "schema",
+          "namespace": "com.example.complex_object.schema.document_types",
           "fields": [
             {
               "name": "street",

--- a/tests/snapshots/cli__nested_object_and_array.snap
+++ b/tests/snapshots/cli__nested_object_and_array.snap
@@ -5,7 +5,7 @@ expression: json
 {
   "type": "record",
   "name": "document",
-  "namespace": "com.example.complex_object.schema",
+  "namespace": "com.example.complex_object",
   "fields": [
     {
       "name": "name",
@@ -22,7 +22,7 @@ expression: json
         {
           "type": "record",
           "name": "address",
-          "namespace": "com.example.complex_object.schema.document_types",
+          "namespace": "com.example.complex_object.document_types",
           "fields": [
             {
               "name": "street",

--- a/tests/snapshots/cli__object_with_boolean_and_number.snap
+++ b/tests/snapshots/cli__object_with_boolean_and_number.snap
@@ -1,0 +1,24 @@
+---
+source: tests/cli.rs
+expression: json
+---
+{
+  "type": "record",
+  "name": "document",
+  "namespace": "object_with_boolean_and_number",
+  "fields": [
+    {
+      "name": "enabled",
+      "type": "boolean",
+      "doc": "Feature toggle"
+    },
+    {
+      "name": "count",
+      "type": [
+        "null",
+        "float"
+      ],
+      "doc": "A non-negative floating-point number"
+    }
+  ]
+}

--- a/tests/snapshots/cli__object_with_const_field.snap
+++ b/tests/snapshots/cli__object_with_const_field.snap
@@ -1,0 +1,25 @@
+---
+source: tests/cli.rs
+expression: json
+---
+{
+  "type": "record",
+  "name": "document",
+  "namespace": "object_with_const_field",
+  "fields": [
+    {
+      "name": "kind",
+      "type": {
+        "name": "kind",
+        "type": "enum",
+        "namespace": "object_with_const_field",
+        "symbols": [
+          "fixedValue"
+        ],
+        "doc": "This field is always 'fixedValue'"
+      },
+      "doc": "This field is always 'fixedValue'",
+      "const": "fixedValue"
+    }
+  ]
+}

--- a/tests/snapshots/cli__object_with_default_value.snap
+++ b/tests/snapshots/cli__object_with_default_value.snap
@@ -1,0 +1,19 @@
+---
+source: tests/cli.rs
+expression: json
+---
+{
+  "type": "record",
+  "name": "document",
+  "namespace": "object_with_default_value",
+  "fields": [
+    {
+      "name": "level",
+      "type": [
+        "null",
+        "int"
+      ],
+      "doc": "Defaults to 1 if not provided"
+    }
+  ]
+}

--- a/tests/snapshots/cli__object_with_defs.snap
+++ b/tests/snapshots/cli__object_with_defs.snap
@@ -1,0 +1,39 @@
+---
+source: tests/cli.rs
+expression: json
+---
+[
+  {
+    "type": "record",
+    "name": "address",
+    "namespace": "object_with_defs",
+    "fields": [
+      {
+        "name": "street",
+        "type": "string"
+      },
+      {
+        "name": "city",
+        "type": "string"
+      }
+    ]
+  },
+  {
+    "type": "record",
+    "name": "document",
+    "namespace": "object_with_defs",
+    "fields": [
+      {
+        "name": "shippingAddress",
+        "type": "object_with_defs.address"
+      },
+      {
+        "name": "billingAddress",
+        "type": [
+          "null",
+          "object_with_defs.address"
+        ]
+      }
+    ]
+  }
+]

--- a/tests/snapshots/cli__object_with_enum_array.snap
+++ b/tests/snapshots/cli__object_with_enum_array.snap
@@ -1,0 +1,27 @@
+---
+source: tests/cli.rs
+expression: json
+---
+{
+  "type": "record",
+  "name": "document",
+  "namespace": "object_with_enum_array",
+  "fields": [
+    {
+      "name": "statuses",
+      "type": {
+        "type": "array",
+        "items": {
+          "type": "enum",
+          "name": "statuses",
+          "namespace": "object_with_enum_array.document_types",
+          "symbols": [
+            "NEW",
+            "PROCESSING",
+            "DONE"
+          ]
+        }
+      }
+    }
+  ]
+}

--- a/tests/snapshots/cli__object_with_explicit_nullable_type.snap
+++ b/tests/snapshots/cli__object_with_explicit_nullable_type.snap
@@ -1,0 +1,18 @@
+---
+source: tests/cli.rs
+expression: json
+---
+{
+  "type": "record",
+  "name": "document",
+  "namespace": "object_with_explicit_nullable_type",
+  "fields": [
+    {
+      "name": "maybeName",
+      "type": [
+        "null",
+        "string"
+      ]
+    }
+  ]
+}

--- a/tests/snapshots/cli__object_with_optional.snap
+++ b/tests/snapshots/cli__object_with_optional.snap
@@ -1,0 +1,22 @@
+---
+source: tests/cli.rs
+expression: json
+---
+{
+  "type": "record",
+  "name": "document",
+  "namespace": "object_with_optional",
+  "fields": [
+    {
+      "name": "id",
+      "type": "int"
+    },
+    {
+      "name": "nickname",
+      "type": [
+        "null",
+        "string"
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
- **fix: get schema namespaces right**
- **fix: namespaces now correct**

The schemas are now matching! `type`/`name` key order is due to Python dict merges, which is not proper anyway so fine to differ

<img width="2090" height="840" alt="Screenshot from 2025-09-01 01-10-52" src="https://github.com/user-attachments/assets/4db0c9a4-888c-4716-a703-158b24952a98" />

- **fix: correct defs handling**

<img width="2134" height="1846" alt="Screenshot from 2025-09-01 02-02-12" src="https://github.com/user-attachments/assets/edc09f15-6731-45d9-89a0-f20ce20ce494" />

- **fix: const and doc handling**

We don't care about the ordering, the enums are again correct our way

<img width="2039" height="2478" alt="Screenshot from 2025-09-01 02-24-54" src="https://github.com/user-attachments/assets/2f97e19e-1212-4b86-8413-87db5254e350" />

There are some leftover ones I've commented out from the test

<img width="1674" height="1011" alt="Screenshot from 2025-09-01 02-25-49" src="https://github.com/user-attachments/assets/eec07598-2b13-44ed-bd4c-70d3a1a1d39e" />
